### PR TITLE
Add species table and lookup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     click
     more_click
     # Web requirements
-    pyobo>=0.6.2
+    pyobo>=0.6.3
     flask
     bootstrap-flask
     flasgger

--- a/src/biolookup/backends/backend.py
+++ b/src/biolookup/backends/backend.py
@@ -28,6 +28,10 @@ class Backend:
         """Get the canonical/preferred (english) name for the identifier in the given resource."""
         raise NotImplementedError
 
+    def get_species(self, prefix: str, identifier: str) -> Optional[str]:
+        """Get the species for the prefix/identifier if it is species-specific."""
+        raise NotImplementedError
+
     def get_definition(self, prefix: str, identifier: str) -> Optional[str]:
         """Get the definition associated with the prefix/identifier."""
         raise NotImplementedError
@@ -120,6 +124,9 @@ class Backend:
         definition = self.get_definition(prefix, identifier)
         if definition:
             rv["definition"] = definition
+        species = self.get_species(prefix, identifier)
+        if species:
+            rv["species"] = species
 
         return rv
 

--- a/src/biolookup/backends/memory_backend.py
+++ b/src/biolookup/backends/memory_backend.py
@@ -16,7 +16,9 @@ class MemoryBackend(Backend):
 
     def __init__(
         self,
+        *,
         get_id_name_mapping,
+        get_id_species_mapping,
         get_alts_to_id,
         summarize_names: Optional[Callable[[], Mapping[str, Any]]],
         summarize_alts: Optional[Callable[[], Mapping[str, Any]]] = None,
@@ -26,6 +28,7 @@ class MemoryBackend(Backend):
         """Initialize the in-memory backend.
 
         :param get_id_name_mapping: A function for getting id-name mappings
+        :param get_id_species_mapping: A function for getting id-species mappings
         :param get_alts_to_id: A function for getting alts-id mappings
         :param summarize_names: A function for summarizing references
         :param summarize_alts: A function for summarizing alts
@@ -33,6 +36,7 @@ class MemoryBackend(Backend):
         :param get_id_definition_mapping: A function for getting id-def mappings
         """
         self.get_id_name_mapping = get_id_name_mapping
+        self.get_id_species_mapping = get_id_species_mapping
         self.get_alts_to_id = get_alts_to_id
         self.get_id_definition_mapping = get_id_definition_mapping
         self._summarize_names = summarize_names
@@ -52,6 +56,11 @@ class MemoryBackend(Backend):
         """Get the name with the id/name getter."""
         id_name_mapping = self.get_id_name_mapping(prefix) or {}
         return id_name_mapping.get(identifier)
+
+    def get_species(self, prefix: str, identifier: str) -> Optional[str]:
+        """Get the species with the id/species getter."""
+        id_species_mapping = self.get_id_species_mapping(prefix) or {}
+        return id_species_mapping.get(identifier)
 
     def get_definition(self, prefix: str, identifier: str) -> Optional[str]:
         """Get the name with the id/definition getter, if available."""

--- a/src/biolookup/backends/sql_backend.py
+++ b/src/biolookup/backends/sql_backend.py
@@ -12,7 +12,13 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
 from .backend import Backend
-from ..constants import ALTS_TABLE_NAME, DEFS_TABLE_NAME, REFS_TABLE_NAME, get_sqlalchemy_uri
+from ..constants import (
+    ALTS_TABLE_NAME,
+    DEFS_TABLE_NAME,
+    REFS_TABLE_NAME,
+    SPECIES_TABLE_NAME,
+    get_sqlalchemy_uri,
+)
 
 __all__ = [
     "RawSQLBackend",
@@ -42,6 +48,7 @@ class RawSQLBackend(Backend):
         refs_table: Optional[str] = None,
         alts_table: Optional[str] = None,
         defs_table: Optional[str] = None,
+        species_table: Optional[str] = None,
         engine: Union[None, str, Engine] = None,
     ):
         """Initialize the raw SQL backend.
@@ -49,6 +56,7 @@ class RawSQLBackend(Backend):
         :param refs_table: A name for the references (prefix-id-name) table. Defaults to 'obo_reference'
         :param alts_table: A name for the alts (prefix-id-alt) table. Defaults to 'obo_alt'
         :param defs_table: A name for the defs (prefix-id-def) table. Defaults to 'obo_def'
+        :param species_table: A name for the defs (prefix-id-species) table. Defaults to 'obo_species'
         :param engine: An engine, connection string, or None if you want the default.
         """
         self.engine = _ensure_engine(engine)
@@ -56,6 +64,7 @@ class RawSQLBackend(Backend):
         self.refs_table = refs_table or REFS_TABLE_NAME
         self.alts_table = alts_table or ALTS_TABLE_NAME
         self.defs_table = defs_table or DEFS_TABLE_NAME
+        self.species_table = species_table or SPECIES_TABLE_NAME
 
     @lru_cache(maxsize=1)
     def count_names(self) -> int:
@@ -138,6 +147,10 @@ class RawSQLBackend(Backend):
     def get_name(self, prefix: str, identifier: str) -> Optional[str]:
         """Get the name with a SQL query to the names table."""
         return self._help_one(self.refs_table, "name", prefix, identifier)
+
+    def get_species(self, prefix: str, identifier: str) -> Optional[str]:
+        """Get the species with a SQL query to the species table."""
+        return self._help_one(self.species_table, "species", prefix, identifier)
 
     def get_definition(self, prefix: str, identifier: str) -> Optional[str]:
         """Get the definition with a SQL query to the definitions table."""

--- a/src/biolookup/constants.py
+++ b/src/biolookup/constants.py
@@ -5,6 +5,7 @@
 import pystow
 
 REFS_TABLE_NAME = "obo_reference"
+SPECIES_TABLE_NAME = "obo_species"
 ALTS_TABLE_NAME = "obo_alt"
 DEFS_TABLE_NAME = "obo_def"
 

--- a/src/biolookup/db/loader.py
+++ b/src/biolookup/db/loader.py
@@ -17,13 +17,19 @@ from textwrap import dedent
 from typing import Optional, Union
 
 import click
-from pyobo.resource_utils import ensure_alts, ensure_definitions, ensure_ooh_na_na, ensure_species
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+from pyobo.resource_utils import ensure_alts, ensure_definitions, ensure_ooh_na_na, ensure_species
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from tabulate import tabulate
 
-from ..constants import ALTS_TABLE_NAME, DEFS_TABLE_NAME, REFS_TABLE_NAME, SPECIES_TABLE_NAME, get_sqlalchemy_uri
+from ..constants import (
+    ALTS_TABLE_NAME,
+    DEFS_TABLE_NAME,
+    REFS_TABLE_NAME,
+    SPECIES_TABLE_NAME,
+    get_sqlalchemy_uri,
+)
 
 __all__ = [
     "load",
@@ -63,6 +69,8 @@ def load(
     :param alts_path: Path to the alts table data
     :param defs_table: Name of the definitions table
     :param defs_path: Path to the definitions table data
+    :param species_table: Name of the species table
+    :param species_path: Path to the species table data
     :param test: Should only a test set of rows be uploaded? Defaults to false.
     :param uri: The URI of the database to connect to.
     """

--- a/src/biolookup/db/loader.py
+++ b/src/biolookup/db/loader.py
@@ -132,7 +132,7 @@ def _load_species(
     *,
     engine: Union[None, str, Engine] = None,
     table: Optional[str] = None,
-    path: Optional[str] = None,
+    path: Union[None, str, Path] = None,
     test: bool = False,
 ):
     engine = _ensure_engine(engine)

--- a/src/biolookup/db/loader.py
+++ b/src/biolookup/db/loader.py
@@ -17,13 +17,13 @@ from textwrap import dedent
 from typing import Optional, Union
 
 import click
+from pyobo.resource_utils import ensure_alts, ensure_definitions, ensure_ooh_na_na, ensure_species
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
-from pyobo.resource_utils import ensure_alts, ensure_definitions, ensure_ooh_na_na
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from tabulate import tabulate
 
-from ..constants import ALTS_TABLE_NAME, DEFS_TABLE_NAME, REFS_TABLE_NAME, get_sqlalchemy_uri
+from ..constants import ALTS_TABLE_NAME, DEFS_TABLE_NAME, REFS_TABLE_NAME, SPECIES_TABLE_NAME, get_sqlalchemy_uri
 
 __all__ = [
     "load",
@@ -47,9 +47,11 @@ def load(
     refs_path: Optional[str] = None,
     alts_path: Optional[str] = None,
     defs_path: Optional[str] = None,
+    species_path: Optional[str] = None,
     refs_table: Optional[str] = None,
     alts_table: Optional[str] = None,
     defs_table: Optional[str] = None,
+    species_table: Optional[str] = None,
     test: bool = False,
     uri: Optional[str] = None,
 ) -> None:
@@ -69,9 +71,12 @@ def load(
         refs_table = REFS_TABLE_NAME
     if defs_table is None:
         defs_table = DEFS_TABLE_NAME
+    if species_table is None:
+        species_table = SPECIES_TABLE_NAME
     _load_alts(engine=engine, table=alts_table, path=alts_path, test=test)
     _load_definition(engine=engine, table=defs_table, path=defs_path, test=test)
     _load_name(engine=engine, table=refs_table, path=refs_path, test=test)
+    _load_species(engine=engine, table=species_table, path=species_path, test=test)
 
 
 def _load_alts(
@@ -109,6 +114,24 @@ def _load_definition(
         test=test,
         target_col="definition",
         use_varchar=False,
+    )
+
+
+def _load_species(
+    *,
+    engine: Union[None, str, Engine] = None,
+    table: Optional[str] = None,
+    path: Optional[str] = None,
+    test: bool = False,
+):
+    engine = _ensure_engine(engine)
+    _load_table(
+        engine=engine,
+        table=table or SPECIES_TABLE_NAME,
+        path=path if path else ensure_species(),
+        test=test,
+        target_col="species",
+        target_col_size=16,
     )
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -34,13 +34,19 @@ DEF_1 = (
     "microtubules. Capturing and antiparallel sliding apart of microtubules "
     "promotes the initial separation of the SPB."
 )
+DEF_2 = "receptor interacting serine/threonine kinase 2"
 DEFS = [
     ("go", "0000073", DEF_1),
     ("go", "0000075", "def_12"),
     ("go", "0000076", "def_13"),
-    ("hgnc", "10020", "def_21"),
+    ("hgnc", "10020", DEF_2),
     ("hgnc", "10021", "def_22"),
     # ("hgnc", "id_23", "def_23"),
+]
+SPECIES = [
+    ("hgnc", "10020", "9606"),
+    ("hgnc", "10021", "9606"),
+    ("hgnc", "10023", "9606"),
 ]
 
 
@@ -81,6 +87,10 @@ class BackendTestCase(unittest.TestCase):
         self.assertEqual(DEF_1, backend.get_definition("go", "0000073"))
         self.assertIsNone(backend.get_definition("hgnc", "1002310101010101"))
 
+        # Test resolution of species
+        self.assertEqual("9606", backend.get_species("hgnc", "10020"))
+        self.assertIsNone(backend.get_species("go", "0030475"))
+
         # Test resolution of alt ids
         self.assertEqual("0000073", backend.get_primary_id("go", "0030475"))
         self.assertIsNone(backend.get_name("go", "0030475"))
@@ -92,6 +102,7 @@ class BackendTestCase(unittest.TestCase):
         self.assertEqual("initial mitotic spindle pole body separation", r["name"])
         self.assertEqual(DEF_1, r["definition"])
         self.assertEqual("go:0000073", r["query"])
+        self.assertNotIn("species", r)
 
         r = backend.resolve("go:0030475")
         self.assertEqual("go", r["prefix"])
@@ -99,6 +110,16 @@ class BackendTestCase(unittest.TestCase):
         self.assertEqual("initial mitotic spindle pole body separation", r["name"])
         self.assertEqual(DEF_1, r["definition"])
         self.assertEqual("go:0030475", r["query"])
+        self.assertNotIn("species", r)
+
+        # Extra test to check species
+        r = backend.resolve("hgnc:10020")
+        self.assertEqual("hgnc", r["prefix"])
+        self.assertEqual("10020", r["identifier"])
+        self.assertEqual("RIPK2", r["name"])
+        self.assertEqual(DEF_2, r["definition"])
+        self.assertEqual("9606", r["species"])
+        self.assertEqual("hgnc:10020", r["query"])
 
 
 @unittest.skipUnless(TEST_URI, reason="No biolookup/test_uri configuration found")


### PR DESCRIPTION
Closes #1 

This PR adds a table for NCBI taxonomy identifiers (keeping in mind that NCBI isn't perfect, but is the most widely used) as well as improvements to the `Backend` abstract class to support getting species information. Like the description, it will be added if it can be found.